### PR TITLE
fix(readme): use a less common character to separate questions and answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ async function extractFlashcards() {
             const answer = answerElement ? answerElement.textContent.trim().replace(/\s+/g, ' ') : '';
             
             if (question && answer) {
-                const cardEntry = `${question} - ${answer}`;
+                const cardEntry = `${question} | ${answer}`;
                 cards.add(cardEntry); 
                 // Log progress without flooding the console
                 if (i % 20 === 0 || i === totalCards - 1) {


### PR DESCRIPTION
`|` seems to occur less often than `-`.

However, I believe a combination of characters like `|||` or a non-ASCII character would also work.